### PR TITLE
Add Windows .bat file to start Ezhil webserver #81

### DIFF
--- a/webserver.bat
+++ b/webserver.bat
@@ -1,0 +1,2 @@
+cd .\web && python ..\ezhil\EZWeb.py
+


### PR DESCRIPTION
* Copy over the webserver.sh as a .bat file
* Remove the shebang line that cmd doesn't like
* Change paths to Windows style `\` delimited